### PR TITLE
chore: add standard pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## What changed and why
+<!-- 1-3 sentences. What problem this solves and what it touches. -->
+
+
+## Security considerations
+<!-- Required for changes touching auth, authorization, data handling, or
+     external interfaces. Otherwise: "N/A - <reason>" (e.g. "N/A - UI copy only"). -->
+N/A -
+
+## Verification
+<!-- Automated checks are visible on this PR. Note anything verified by hand. -->
+- Manually verified:
+
+## Rollback
+<!-- Default applies to most changes. Overwrite for migrations, config,
+     or infra changes where a revert alone won't restore state. -->
+Revert the merge commit.
+
+## Review attestation
+- [ ] I reviewed the full diff before approving.


### PR DESCRIPTION
## What changed and why
Adds the standard pull request template at `.github/pull_request_template.md` so it is prefilled on every new PR in this repo. Adds one file; no code paths touched.

## Security considerations
N/A - adds a markdown template only, no auth, data handling, or external interfaces.

## Verification
- Manually verified: file content byte-compared against the agreed template after commit (660 bytes).
- The template will apply to PRs opened after this merges, since GitHub reads it from the default branch.

## Rollback
Revert the merge commit.

## Review attestation
- [ ] I reviewed the full diff before approving.
